### PR TITLE
Escape Text elements

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -44,7 +44,7 @@ type Person struct {
 	URI   string `xml:"uri,omitempty"`
 	Email string `xml:"email,omitempty"`
 
-	Extension []Extension `xml:",any,omitempty"`
+	Extension []interface{} `xml:",any,omitempty"`
 }
 
 // TimeStr is a date/time attribute that is in the correct
@@ -132,7 +132,7 @@ type Entry struct {
 	Updated     TimeStr    `xml:"updated"`
 
 	// Custom elements
-	Extension []Extension `xml:",any,omitempty"`
+	Extension []interface{} `xml:",any,omitempty"`
 }
 
 // Feed is the top level ATOM syndication element. Validation:
@@ -165,5 +165,5 @@ type Feed struct {
 	Entry []Entry `xml:"entry"`
 
 	// Custom elements
-	Extension []Extension `xml:",any,omitempty"`
+	Extension []interface{} `xml:",any,omitempty"`
 }

--- a/feed.go
+++ b/feed.go
@@ -21,7 +21,7 @@ type Text struct {
 
 	Type string `xml:"type,attr,omitempty"`
 	Src  string `xml:"src,attr,omitempty"`
-	Body string `xml:",innerxml"`
+	Body string `xml:",chardata"`
 }
 
 // Extension represents a custom atom element.


### PR DESCRIPTION
The `innerxml` flag doesn't escape the text, but `chardata` or `cdata` does.